### PR TITLE
MultiLineCsvParser - parse(String) now does null check

### DIFF
--- a/src/main/java/net/quux00/simplecsv/MultiLineCsvParser.java
+++ b/src/main/java/net/quux00/simplecsv/MultiLineCsvParser.java
@@ -3,6 +3,7 @@ package net.quux00.simplecsv;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Collections;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -146,7 +147,10 @@ public class MultiLineCsvParser implements CsvParser {
   @Override
   public List<String> parse(String s) {
     if (s == null) {
-      return null;
+      throw new IllegalArgumentException("I cannot parse a null");
+    }
+    if (s.isEmpty()) {
+      return Collections.<String>emptyList();
     }
     try {
       return parseNext(new StringReader(s));


### PR DESCRIPTION
parse(String) now checks for null and throws and IllegalArgumentException on a null.
and empty String produces an empty List.